### PR TITLE
Fix repository URL in install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ if [ -d "$INSTALL_DIR" ]; then
     git -C "$INSTALL_DIR" pull --rebase
 else
     echo "📥 Cloning DeepSeek Harness repository..."
-    git clone https://github.com/Oeditus/ragex.git "$INSTALL_DIR"
+    git clone https://github.com/Oeditus/dsh.git "$INSTALL_DIR"
 fi
 
 cd "$INSTALL_DIR"

--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ if [ -d "$INSTALL_DIR" ]; then
     git -C "$INSTALL_DIR" pull --rebase
 else
     echo "📥 Cloning DeepSeek Harness repository..."
-    git clone https://github.com/Oeditus/ragec.git "$INSTALL_DIR"
+    git clone https://github.com/Oeditus/ragex.git "$INSTALL_DIR"
 fi
 
 cd "$INSTALL_DIR"


### PR DESCRIPTION
It seems install script should be pointing to your repo `Oeditus/ragex`. In the script is is typed with a `c`: `ragec`.